### PR TITLE
Update binaryConverter.java

### DIFF
--- a/binaryConverter/binaryConverter.java
+++ b/binaryConverter/binaryConverter.java
@@ -1,4 +1,4 @@
-//yeah nah abandoning this its horribly innefficient
+// problem was that you were multplying the ascii values of 0 and 1
 
 public class binaryConverter {
 	
@@ -7,18 +7,15 @@ public class binaryConverter {
 		String binary = IBIO.input("enter a binary number (8 bit): ");
 		char[] xx = binary.toCharArray();
 		int values[] = {128,64,32,16,8,4,2,1};
-		int mult = 1;
 		int dValue = 0;
 		int fValue = 0;
 		
-		for(int i = binary.length()-1; i>-1; i--){
-			dValue = xx[i]*mult;
-			mult = mult*2;
+		for(int i = binary.length()-1; i>-1; i--) {
+			dValue = Character.getNumericValue(xx[i])*values[i];
+			// dValue = (xx[i] - 48) * values[i];
 			fValue += dValue;
-
-			}
-			System.out.println(fValue);
-		
+		}
+		System.out.println(fValue);
 	}
 }
 


### PR DESCRIPTION
The reason you're getting larger values than expected is because you're multiplying the ASCII values of the `char` instead of the `int`. There are multiple ways to work around this, one could be manually subtracting 48 from xx[i] (as the ASCII value of 0 is 48): `dValue = (xx[I] - 48) * values[i];` or using `Character.getNumericValue(xx[i])`. Hope this helps!